### PR TITLE
[dev] Remove references to removed Auth and Device Manager readthedocs pages

### DIFF
--- a/source/components-and-apis.rst
+++ b/source/components-and-apis.rst
@@ -41,7 +41,7 @@ Components
     -
   * - Auth
     - `GitHub - auth`_
-    - `Auth  doc.`_
+    -
     - `API - auth`_
   * - History
     - `GitHub - history`_
@@ -327,8 +327,7 @@ dojot.
 
 .. _GitHub - auth: https://github.com/dojot/auth
 .. _API - auth: https://dojot.github.io/auth/apiary_v0.4.3.html
-.. _Auth  doc.: http://dojotdocs.readthedocs.io/projects/auth/en/latest/
-.. _Messages - auth: https://dojotdocs.readthedocs.io/projects/auth/en/latest/kafka-messages.html
+.. _Messages - auth: https://github.com/dojot/auth/tree/v0.4.3#kafka-messages
 
 .. _GitHub - history: https://github.com/dojot/history
 .. _API - history: https://dojot.github.io/history/apiary_v0.4.3.html

--- a/source/concepts.rst
+++ b/source/concepts.rst
@@ -94,7 +94,7 @@ associated to it - they are tightly linked to the original template so that any
 template update will reflect all associated devices.
 
 The component responsible for managing devices (both real and virtual) and
-templates is `DeviceManager`_ . 
+templates is `DeviceManager`_ .
 
 `DeviceManager documentation`_ explains in more
 depth all the available operations.
@@ -123,11 +123,10 @@ The component responsible for dealing with such flows is `flowbroker`_.
 .. _JSON Web Token: https://tools.ietf.org/html/rfc7519
 .. _jwt.io: https://jwt.io/
 .. _auth: https://github.com/dojot/auth
-.. _auth documentation: http://dojotdocs.readthedocs.io/projects/auth/
 .. _docker-compose: https://github.com/dojot/docker-compose
 .. _DeviceManager: https://github.com/dojot/device-manager
-.. _DeviceManager documentation: http://dojotdocs.readthedocs.io/projects/DeviceManager/
-.. _DeviceManager how-to: http://dojotdocs.readthedocs.io/projects/DeviceManager/en/latest/using-device-manager.html#using-devicemanager
+.. _DeviceManager documentation: https://github.com/dojot/device-manager
+.. _DeviceManager how-to: https://github.com/dojot/device-manager#how-to-use
 .. _mashup: https://github.com/dojot/mashup
 .. _mosquitto: https://projects.eclipse.org/projects/technology.mosquitto
 .. _history APIs: https://dojot.github.io/history-ws/apiary_latest.html

--- a/source/faq/faq.rst
+++ b/source/faq/faq.rst
@@ -462,7 +462,3 @@ could be integrated with dojot:
 
 All these endpoints should bear an access token, which is retrieved as
 described in the question `How can I use them?`_.
-
-
-.. _Device-Manager how-to - sending actuation messages: http://dojotdocs.readthedocs.io/projects/DeviceManager/en/latest/using-device-manager.html#sending-actuation-messages-to-devices
-.. _flowbroker: https://github.com/dojot/flowbroker

--- a/source/internal-communication.rst
+++ b/source/internal-communication.rst
@@ -540,7 +540,6 @@ check `DataBroker documentation`_.
 .. _API - data-broker: https://dojot.github.io/data-broker/apiary_latest.html
 .. _Kafka partitions and replicas: https://sookocheff.com/post/kafka/kafka-in-a-nutshell/#what-is-kafka
 .. _DataBroker documentation: https://dojot.github.io/data-broker/apiary_latest.html
-.. _Device Manager messages: https://dojotdocs.readthedocs.io/projects/DeviceManager/en/latest/kafka-messages.html
 .. _Kafka's official documentation: https://kafka.apache.org/documentation/
 .. _Kong's documentation: https://docs.konghq.com/0.14.x/getting-started/configuring-a-service/
 .. _Kong JWT plugin page: https://docs.konghq.com/hub/kong-inc/jwt/

--- a/source/locale/pt_BR/LC_MESSAGES/components-and-apis.po
+++ b/source/locale/pt_BR/LC_MESSAGES/components-and-apis.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dojot 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-02 16:48-0300\n"
+"POT-Creation-Date: 2020-10-05 17:05-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,10 +141,6 @@ msgstr ""
 
 #: ../../source/components-and-apis.rst:43
 msgid "`GitHub - auth`_"
-msgstr ""
-
-#: ../../source/components-and-apis.rst:44
-msgid "`Auth  doc.`_"
 msgstr ""
 
 #: ../../source/components-and-apis.rst:45

--- a/source/using-api-interface.rst
+++ b/source/using-api-interface.rst
@@ -146,7 +146,7 @@ Note that the template ID is 1 (line 35), if you have already created another te
 To create a template based on it, send the following request to dojot:
 
 .. code-block:: bash
-    
+
     curl -X POST http://localhost:8000/device \
     -H "Authorization: Bearer ${JWT}" \
     -H 'Content-Type:application/json' \
@@ -362,11 +362,9 @@ This message contains all previously sent values.
 .. _JSON Web Token: https://tools.ietf.org/html/rfc7519
 .. _jwt.io: https://jwt.io/
 .. _auth: https://github.com/dojot/auth
-.. _auth documentation: http://dojotdocs.readthedocs.io/projects/auth/
 .. _docker-compose: https://github.com/dojot/docker-compose
 .. _DeviceManager: https://github.com/dojot/device-manager
-.. _DeviceManager documentation: http://dojotdocs.readthedocs.io/projects/DeviceManager/
-.. _DeviceManager how-to: http://dojotdocs.readthedocs.io/projects/DeviceManager/en/latest/using-device-manager.html#using-devicemanager
+.. _DeviceManager how-to: https://github.com/dojot/device-manager#how-to-use
 .. _mashup: https://github.com/dojot/mashup
 .. _mosquitto: https://projects.eclipse.org/projects/technology.mosquitto
 .. _curl: https://curl.haxx.se/


### PR DESCRIPTION
The Device Manager and Auth services had their own read the docs site. This no longer is valid; nor it is their referenced pages in this documentation. I forgot some of the Device Manager links in some other pages in here, this PR gets rid of all of them, and also removes the links to the Auth pages.

Related to https://github.com/dojot/dojot/issues/1584 and https://github.com/dojot/dojot/issues/1473.