### PR TITLE
[0.5.0] - Iotagent Architecture Doc Update

### DIFF
--- a/source/iotagent-architecture.rst
+++ b/source/iotagent-architecture.rst
@@ -79,8 +79,8 @@ agent and they are categorized in the following groups:
    detect device liveness.
 
    An extra feature that an IoT agent might implement is firmware updates.
-   Depending on is underlying protocol, it might be possible to do such thing
-   in a easy, secure and reliable way.
+   Depending on its underlying protocol, it might be possible to do such thing
+   in an easy, secure and reliable way.
 
 Each one of these groups is going to be detailed in the following sections.
 

--- a/source/iotagent-architecture.rst
+++ b/source/iotagent-architecture.rst
@@ -520,5 +520,5 @@ to facilitate the development of an IotAgent.
 
 There are two libraries:
 
- - node.js **recommended** (https://www.npmjs.com/package/@dojot/microservice-sdk)
+ - node.js **recommended** (https://www.npmjs.com/package/@dojot/iotagent-nodejs)
  - java (https://jitpack.io/#dojot/iotagent-java)

--- a/source/iotagent-architecture.rst
+++ b/source/iotagent-architecture.rst
@@ -515,14 +515,10 @@ and vice-versa.
 Libraries to assist the development of new IotAgents
 ====================================================
 
-We have libraries that abstract some points describe in previous topics
+We have libraries that abstract some points described in previous topics
 to facilitate the development of an IotAgent.
 
 There are two libraries:
 
- - node.js **recommended** (https://www.npmjs.com/package/@dojot/iotagent-nodejs)
- - java (https://github.com/dojot/iotagent-java)
-
-
-
-
+ - node.js **recommended** (https://www.npmjs.com/package/@dojot/microservice-sdk)
+ - java (https://jitpack.io/#dojot/iotagent-java)

--- a/source/locale/pt_BR/LC_MESSAGES/iotagent-architecture.po
+++ b/source/locale/pt_BR/LC_MESSAGES/iotagent-architecture.po
@@ -224,7 +224,7 @@ msgstr ""
 #: ../../source/iotagent-architecture.rst:81
 msgid ""
 "An extra feature that an IoT agent might implement is firmware updates. "
-"Depending on is underlying protocol, it might be possible to do such thing in a "
+"Depending on its underlying protocol, it might be possible to do such thing in an "
 "easy, secure and reliable way."
 msgstr ""
 "Um recurso extra que um agente IoT pode implementar são as atualizações de "
@@ -881,7 +881,7 @@ msgstr "Bibliotecas para auxiliar no desenvolvimento de novos agentes IoT"
 
 #: ../../source/iotagent-architecture.rst:518
 msgid ""
-"We have libraries that abstract some points describe in previous topics to "
+"We have libraries that abstract some points described in previous topics to "
 "facilitate the development of an IotAgent."
 msgstr ""
 "Temos bibliotecas que abstraem alguns pontos descritos nos tópicos anteriores "
@@ -898,5 +898,5 @@ msgstr ""
 "node.js **recomendada** (https://www.npmjs.com/package/@dojot/iotagent-nodejs)"
 
 #: ../../source/iotagent-architecture.rst:524
-msgid "java (https://github.com/dojot/iotagent-java)"
+msgid "java (https://jitpack.io/#dojot/iotagent-java)"
 msgstr ""


### PR DESCRIPTION
Subtle modifications for Iotagent architecture text.

- Grammar erros
- Update "iotagent-java" link to point to jitpack repository instead of github

dojot/dojot#1761